### PR TITLE
Revert "set bootstrap.min.js script source to https://maxcdn.bootstrapcdn.com…"

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,11 @@
   <script>
     window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')
   </script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" ></script> 
+  <script src="../../dist/js/bootstrap.min.js"></script>
+  <!-- Just to make our placeholder images work. Don't actually copy the next line! -->
+
+  <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
+  <script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>
   <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="0 0 500 500" preserveAspectRatio="none" style="display: none; visibility: hidden; position: absolute; top: -100%; left: -100%;">
     <defs>
       <style type="text/css"></style>


### PR DESCRIPTION
Something broke when I removed/edited these scripts. Page now grayed out on sign-in. Going to be more methodical about this and try again.
